### PR TITLE
Update github pages workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     
@@ -96,7 +96,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,20 +5,31 @@ on:
     branches: [ main ]
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: '3.9'
+    
+    - name: Setup Pages
+      uses: actions/configure-pages@v5
     
     - name: Install dependencies
       run: |
@@ -30,8 +41,18 @@ jobs:
       run: |
         cd docs && make html
     
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
+    - name: Upload Pages artifact
+      uses: actions/upload-pages-artifact@v3
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/_build/html
+        path: docs/_build/html
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Update GitHub Actions workflows to use latest versions and comply with GitHub Pages deployment best practices.

The `docs.yml` workflow was updated to use the official GitHub Pages deployment actions (`actions/configure-pages`, `actions/upload-pages-artifact`, `actions/deploy-pages`) instead of a third-party action, along with the required permissions and job structure. Additionally, `actions/checkout` and `actions/setup-python` were updated to their latest stable versions across both `docs.yml` and `ci.yml` for improved compatibility and security.

---

[Open in Web](https://www.cursor.com/agents?id=bc-9ecfcf68-fac6-4fc0-ba2d-653cfa90c640) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-9ecfcf68-fac6-4fc0-ba2d-653cfa90c640)